### PR TITLE
feat: extract URL from link messages (app_type=5)

### DIFF
--- a/wechat_cli/core/messages.py
+++ b/wechat_cli/core/messages.py
@@ -195,6 +195,9 @@ def _format_app_message_text(content, local_type, is_group, chat_username, chat_
                                 return f"[文件] {title}\n  {os.path.join(file_dir, f)}"
         return f"[文件] {title}" if title else "[文件]"
     if app_type == 5:
+        url = _collapse_text(appmsg.findtext('url') or '')
+        if url:
+            return f"[链接] {title}\n  {url}" if title else f"[链接]\n  {url}"
         return f"[链接] {title}" if title else "[链接]"
     if app_type in (33, 36, 44):
         return f"[小程序] {title}" if title else "[小程序]"


### PR DESCRIPTION
## What changed

Extract the `<url>` field from link messages (app_type=5) and include it in the formatted output.

## Before

```
[链接] 如何用AI提升10倍效率
```

## After

```
[链接] 如何用AI提升10倍效率
  https://mp.weixin.qq.com/s/wx7rLvP_W8-cXfb_jdIo9g
```

## Why

WeChat group chats frequently share Official Account article links. Without the URL, users cannot:
- Programmatically scrape article content
- Build automated content collection workflows
- Search for specific articles by URL

The XML payload already contains the `<url>` field — it was simply not being extracted.

## Impact

- Only affects messages with `app_type == 5` (links)
- Links without a URL field remain unchanged: `[链接] title`
- No breaking changes to existing output format